### PR TITLE
Define plugin dependencies

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,7 +12,11 @@ use RainLab\Pages\Controllers\Index as StaticPage;
  * RicheditorSnippets Plugin Information File
  */
 class Plugin extends PluginBase
-{
+{  
+    /**
+     * @var array Plugin dependencies
+     */
+    public $require = ['RainLab.Pages'];
 
     /**
      * Returns information about this plugin.


### PR DESCRIPTION
The plugin should require the Pages plugin, as it definetly breaks when it is not available.