### PR TITLE
Allow to render simple component based snippets not defined in the layout

### DIFF
--- a/classes/SnippetParser.php
+++ b/classes/SnippetParser.php
@@ -33,6 +33,13 @@ class SnippetParser
                 $generatedMarkup = $controller->renderPartial($partialName, $snippetInfo['properties']);
             }
             else {
+                // If the component was not included in the layout, load it dynamically.
+                // It is required to manually call the onRun method because the CMS is supposed to have ran it when loading the layout.
+                if (!$controller->findComponentByName($snippetCode)) {
+                    $component = $controller->addComponent($snippetInfo['component'], $snippetCode, $snippetInfo['properties'], true);
+                    $component->onRun();
+                }
+                
                 $generatedMarkup = $controller->renderComponent($snippetCode);
             }
 


### PR DESCRIPTION
This fixes issue #4.

The problem is that October doesn't allow to render a component (snippet) that was not included in the layout. The documentation of the plugin doesn't tell about it, so it is counter intuitive to have them listed in the dropdown but to not see them in the output.
This fix dynamically loads the component in the controller if it was not yet.

This allows embedding snippets from other plugins, such embed plugins for example. This is useful because these plugins typically have a lot of snippets, and it's annoying to add them all to the layout(s) in order to be able to use them.

However, there are some components that cannot work, even with this fix: all components using ajax handlers still need to be included in the layout, because the dynamic components loading of this fix is done only on page render. It would be great to document this point.

One way that could be explored to fix this ajax issue may be to store somewhere (cache?) which components where dynamically loaded on which page during the rendering and load the same components when the cms is later called in the context of an ajax request.
I havn't tried to see if it is possible, but I think it would add a lot of complexity...