### PR TITLE
Support for OctoberCMS 420

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -27,4 +27,4 @@ Route::get('/toughdeveloper/snippets/list.js', function()
         ->keyBy('snippet');
 
     return '$.oc.snippets = ' . $snippets;
-});
+})->middleware('web');


### PR DESCRIPTION
The problem is that currently on upcoming build 420 of October, if you try to open a page containing a rich editor, you get a 401 when calling the list.js route. This then causes the backend page editor to break, until the page is closed and reopen.

Appart this, the plugin seems to work fine on October 420.

See this issue for details on the fix: https://github.com/octobercms/october/issues/3052