### PR TITLE
Passing Content-Type as text/javascript on route

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -26,5 +26,5 @@ Route::get('/toughdeveloper/snippets/list.js', function()
         })
         ->keyBy('snippet');
 
-    return '$.oc.snippets = ' . $snippets;
+    return Response::make('$.oc.snippets = '.$snippets)->header('Content-Type', 'text/javascript');
 });


### PR DESCRIPTION
Refused to execute script from 'toughdeveloper/snippets/list.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.

The route should return header type in text/javascript not text/html. Passing Content-Type: text/html; when MIME type checking is enabled will failed to load.